### PR TITLE
Add option to copy selected color without opening window

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A script that provides a working color picker for wayland and wlroots
 by leveraging [grim](https://github.com/emersion/grim) and
 [slurp](https://github.com/emersion/slurp).
 
+## Usage
+  - Command `wl-color-picker` - Select position on screen and open color picker window
+  - Command `wl-color-picker clipboard` - Select position on screen without opening color picker window, just copy selected color to clipboard
+
+
 ## Inspiration
 
 This script is possible by the information provided on the following

--- a/wl-color-picker.sh
+++ b/wl-color-picker.sh
@@ -45,20 +45,24 @@ else
     )
 fi
 
-# Display a color picker and store the returned rgb color
-rgb_color=$(zenity --color-selection \
-    --title="Copy color to Clipboard" \
-    --color="${color}"
-)
+if [ "$1" == "clipboard" ]; then
+	echo $color | wl-copy -n
+else
+	# Display a color picker and store the returned rgb color
+	rgb_color=$(zenity --color-selection \
+	    --title="Copy color to Clipboard" \
+	    --color="${color}"
+	)
 
-# Execute if user didn't click cancel
-if [ "$rgb_color" != "" ]; then
-    # Convert rgb color to hex
-    hex_color="#"
-    for value in $(echo "${rgb_color}" | grep -E -o -m1 '[0-9]+'); do
-        hex_color="$hex_color$(printf "%.2x" $value)"
-    done
+	# Execute if user didn't click cancel
+	if [ "$rgb_color" != "" ]; then
+	    # Convert rgb color to hex
+	    hex_color="#"
+	    for value in $(echo "${rgb_color}" | grep -E -o -m1 '[0-9]+'); do
+       		hex_color="$hex_color$(printf "%.2x" $value)"
+	    done
 
-    # Copy user selection to clipboard
-    echo $hex_color | wl-copy -n
+    	# Copy user selection to clipboard
+    	echo $hex_color | wl-copy -n
+	fi
 fi


### PR DESCRIPTION
That's nice to have option to quickly copy color without opening window with color picker
So I added argument `wl-color-picker clipboard` which doesn't open a window