### PR TITLE
Replaced Bash specific Syntax with POSIX compliant equivalent

### DIFF
--- a/wl-color-picker.sh
+++ b/wl-color-picker.sh
@@ -98,5 +98,8 @@ else
 
         # Copy user selection to clipboard
         echo $hex_color | wl-copy -n
+        if [ $NO_NOTIFY -ne 1 ]; then
+            notify-send "Color copied to clipboard." $hex_color
+        fi
     fi
 fi

--- a/wl-color-picker.sh
+++ b/wl-color-picker.sh
@@ -70,7 +70,7 @@ if command -v /usr/bin/gm > /dev/null 2>&1; then
     )
 else
     color=$(grim -g "$position" -t png - \
-        | convert - -format '%[pixel:p{0,0}]' txt:- \
+        | magick - -format '%[pixel:p{0,0}]' txt:- \
         | tail -n 1 \
         | cut -d ' ' -f 4
     )

--- a/wl-color-picker.sh
+++ b/wl-color-picker.sh
@@ -60,7 +60,7 @@ position=$(slurp -b 00000000 -p)
 sleep 1
 
 # Store the hex color value using graphicsmagick or imagemagick.
-if command -v /usr/bin/gm &> /dev/null; then
+if command -v /usr/bin/gm > /dev/null 2>&1; then
     color=$(grim -g "$position" -t png - \
         | /usr/bin/gm convert - -format '%[pixel:p{0,0}]' txt:- \
         | tail -n 1 \


### PR DESCRIPTION
Just a small change to make the script compatible with different POSIX compliant shells (e.g. DASH), that do not support bash syntax. The script would engage in unexpected behavior when run with dash, which is bad because of the implied compatibility by using `#!/bin/sh`. Specifically, zenity would always open with color #FFFFFF. Maybe this is the cause of #7 ?